### PR TITLE
Infer `if TYPE_CHECKING` imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
           - click
           - msgspec
           - anyio
+          - rich-click

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Unasyncd features:
 
 ## Table of contents
 
+<!-- TOC -->
 * [Unasync](#unasync)
   * [Why?](#why)
   * [Why unasyncd?](#why-unasyncd)
+  * [Table of contents](#table-of-contents)
   * [What can be transformed?](#what-can-be-transformed)
     * [Asynchronous functions](#asynchronous-functions)
     * [`await`](#await)
@@ -61,7 +63,8 @@ Unasyncd features:
     * [CLI](#cli)
     * [As a pre-commit hook](#as-a-pre-commit-hook)
     * [Configuration](#configuration)
-      * [Options](#options)
+      * [File](#file)
+      * [CLI options](#cli-options)
       * [Exclusions](#exclusions)
       * [Extending name replacements](#extending-name-replacements)
     * [Handling of imports](#handling-of-imports)
@@ -375,21 +378,20 @@ Unasyncd is available as a pre-commit hook:
 Unasyncd can be configured via a `pyproject.toml` file, a dedicated `.unasyncd.toml`
 file or the command line interface.
 
-#### Options
+#### File
 
-| config file key             | CLI                             | default | description                                                                        |
-|-----------------------------|---------------------------------|---------|------------------------------------------------------------------------------------|
-| `files`                     |                                 | -       | A table mapping source file names / directories to target file names / directories |
-| `exclude`                   | N/A                             | -       | An array of names to exclude from transformation                                   |
-| `per_file_exclude`          | N/A                             | -       | A table mapping files names to an array of names to exclude from transformation    |
-| `add_replacements`          | N/A                             | -       | A table of additional name replacements                                            |
-| `per_file_add_replacements` | N/A                             | -       | A table mapping file names to tables of additional replacements                    |
-| `transform_docstrings`      | `-d` / `--transform-docstrings` | false   | Enable transformation of docstrings                                                |
-| `add_editors_note`          | `--add-editors-note`            | false   | Add a note on top of the generated files                                           |
-| `remove_unuse_imports`      | `--remove-unused-imports`       | false   | Remove imports that have become unused after the transformation                    |
-| `no_cache`                  | `--no-cache`                    | false   | Disable caching                                                                    |
-| `force_regen`               | `--force-regen`                 | false   | Always regenerate files, regardless if their content has changed                   |
-| N/A                         | `-c` / `--config``              | -       | Specify an alternative configuration file                                          |
+| config file key               | type  | default | description                                                                        |
+|-------------------------------|-------|---------|------------------------------------------------------------------------------------|
+| `files`                       | table | -       | A table mapping source file names / directories to target file names / directories |
+| `exclude`                     | array | -       | An array of names to exclude from transformation                                   |
+| `per_file_exclude`            | table | -       | A table mapping files names to an array of names to exclude from transformation    |
+| `add_replacements`            | table | -       | A table of additional name replacements                                            |
+| `per_file_add_replacements`   | table | -       | A table mapping file names to tables of additional replacements                    |
+| `transform_docstrings`        | bool  | false   | Enable transformation of docstrings                                                |
+| `add_editors_note`            | bool  | false   | Add a note on top of the generated files                                           |
+| `infer_type_checking_imports` | bool  | true    | Infer if new imports should be added to an 'if TYPE_CHECKING' block                |
+| `cache`                       | bool  | true    | Cache transformation results                                                       |
+| `force_regen`                 | bool  | false   | Always regenerate files, regardless if their content has changed                   |
 
 **Example**
 
@@ -406,6 +408,35 @@ no_cache = false
 no_cache = false
 force_regen = false
 ```
+
+#### CLI options
+
+*Feature flags corresponding to configuration values*
+
+| option                             | description                                                         |
+|------------------------------------|---------------------------------------------------------------------|
+| `--cache`                          | Cache transformation results                                        |
+| `--no-cache `                      | Don't cache transformation results                                  |
+| `--transform-docstrings`           | Enable transformation of docstrings                                 |
+| `--no-transform-docstrings`        | Inverse of `--transform-docstrings`                                 |
+| `--infer-type-checking-imports`    | Infer if new imports should be added to an 'if TYPE_CHECKING' block |
+| `--no-infer-type-checking-imports` | Inverse of `infer-type-checking-imports`                            |
+| `--add-editors-note`               | Add a note on top of each generated file                            |
+| `--no-add-editors-note`            | Inverse of `--add-editors-note`                                     |
+| `--force`                          | Always regenerate files, regardless if their content has changed    |
+| `--no-force`                       | Inverse of `--force`                                                |
+| `--check`                          | Don't write changes back to files                                   |
+| `--write`                          | Inverse of `--check`                                                |
+
+
+*Additional CLI options*
+
+| option      | description                          |
+|-------------|--------------------------------------|
+| `--config`  | Alternative configuration file       |
+| `--verbose` | Increase verbosity of console output |
+| `--quiet`   | Suppress all console output          |
+
 
 #### Exclusions
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -448,6 +448,24 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "rich-click"
+version = "1.6.1"
+description = "Format click help output nicely with rich"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "rich-click-1.6.1.tar.gz", hash = "sha256:f8ff96693ec6e261d1544e9f7d9a5811c5ef5d74c8adb4978430fc0dac16777e"},
+    {file = "rich_click-1.6.1-py3-none-any.whl", hash = "sha256:0fcf4d1a09029d79322dd814ab0b2e66ac183633037561881d45abae8a161d95"},
+]
+
+[package.dependencies]
+click = ">=7"
+rich = ">=10.7.0"
+
+[package.extras]
+dev = ["pre-commit"]
+
+[[package]]
 name = "setuptools"
 version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -534,4 +552,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "259d11cf8b660b2a9e1a646e25f60b9a8f1e7394ac54cdec36c82d684b029f14"
+content-hash = "13fb73d2ca652aa2d2b0cba414c7f3493b24d3668954aaa20290bc9713dd34d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ rich = "^13.4.1"
 anyio = "^3.7.0"
 msgspec = "^0.15.1"
 tomli-w = "^1.0.0"
+rich-click = "^1.6.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -115,6 +115,7 @@ def test_set_config_file(
     assert mock_load_config.call_args_list[0].kwargs["path"] == config_path
 
 
+@pytest.mark.parametrize("no_infer_type_checking_import", [True, False])
 @pytest.mark.parametrize("transform_docstrings", [True, False])
 @pytest.mark.parametrize("add_editors_note", [True, False])
 @pytest.mark.parametrize("check_only", [True, False])
@@ -130,6 +131,7 @@ def test_config_options(
     target_file: Path,
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    no_infer_type_checking_import: bool,
 ):
     monkeypatch.chdir(tmp_path)
     arguments = [f"{source_file}:{target_file}"]
@@ -146,6 +148,9 @@ def test_config_options(
     if force_regen:
         arguments.append("--force")
 
+    if no_infer_type_checking_import:
+        arguments.append("--no-infer-type-checking-imports")
+
     result = runner.invoke(main, arguments)
 
     assert not result.exception
@@ -156,6 +161,7 @@ def test_config_options(
     assert config.add_editors_note is add_editors_note
     assert config.check_only is check_only
     assert config.force_regen is force_regen
+    assert config.infer_type_checking_imports is not no_infer_type_checking_import
 
 
 def test_pass_files(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -115,41 +115,42 @@ def test_set_config_file(
     assert mock_load_config.call_args_list[0].kwargs["path"] == config_path
 
 
-@pytest.mark.parametrize("no_infer_type_checking_import", [True, False])
-@pytest.mark.parametrize("transform_docstrings", [True, False])
-@pytest.mark.parametrize("add_editors_note", [True, False])
-@pytest.mark.parametrize("check_only", [True, False])
-@pytest.mark.parametrize("force_regen", [True, False])
-def test_config_options(
+@pytest.mark.parametrize(
+    "flag_value, config_value",
+    [
+        (True, True),
+        (False, False),
+        (True, False),
+        (False, True),
+    ],
+)
+def test_feature_flags(
     runner: CliRunner,
     mock_unasync_files: MagicMock,
-    transform_docstrings: bool,
-    add_editors_note: bool,
-    check_only: bool,
-    force_regen: bool,
     source_file: Path,
     target_file: Path,
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
-    no_infer_type_checking_import: bool,
+    flag_value: bool,
+    config_value: bool,
 ):
     monkeypatch.chdir(tmp_path)
     arguments = [f"{source_file}:{target_file}"]
 
-    if transform_docstrings:
-        arguments.append("--transform-docstrings")
+    arguments.extend(
+        [
+            f"--{'no-' if not flag_value else ''}{flag}"
+            for flag in [
+                "transform-docstrings",
+                "add-editors-note",
+                "infer-type-checking-imports",
+                "force",
+                "cache",
+            ]
+        ]
+    )
 
-    if add_editors_note:
-        arguments.append("--add-editors-note")
-
-    if check_only:
-        arguments.append("--check")
-
-    if force_regen:
-        arguments.append("--force")
-
-    if no_infer_type_checking_import:
-        arguments.append("--no-infer-type-checking-imports")
+    arguments.append("--check" if flag_value else "--write")
 
     result = runner.invoke(main, arguments)
 
@@ -157,11 +158,12 @@ def test_config_options(
     assert result.exit_code == 0
     config = mock_unasync_files.call_args_list[0].kwargs["config"]
 
-    assert config.transform_docstrings is transform_docstrings
-    assert config.add_editors_note is add_editors_note
-    assert config.check_only is check_only
-    assert config.force_regen is force_regen
-    assert config.infer_type_checking_imports is not no_infer_type_checking_import
+    assert config.transform_docstrings is flag_value
+    assert config.add_editors_note is flag_value
+    assert config.force_regen is flag_value
+    assert config.infer_type_checking_imports is flag_value
+    assert config.cache is flag_value
+    assert config.check_only is flag_value
 
 
 def test_pass_files(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -116,7 +116,6 @@ def test_set_config_file(
 
 
 @pytest.mark.parametrize("transform_docstrings", [True, False])
-@pytest.mark.parametrize("remove_unused_imports", [True, False])
 @pytest.mark.parametrize("add_editors_note", [True, False])
 @pytest.mark.parametrize("check_only", [True, False])
 @pytest.mark.parametrize("force_regen", [True, False])
@@ -124,7 +123,6 @@ def test_config_options(
     runner: CliRunner,
     mock_unasync_files: MagicMock,
     transform_docstrings: bool,
-    remove_unused_imports: bool,
     add_editors_note: bool,
     check_only: bool,
     force_regen: bool,
@@ -138,9 +136,6 @@ def test_config_options(
 
     if transform_docstrings:
         arguments.append("--transform-docstrings")
-
-    if remove_unused_imports:
-        arguments.append("--remove-unused-imports")
 
     if add_editors_note:
         arguments.append("--add-editors-note")
@@ -158,7 +153,6 @@ def test_config_options(
     config = mock_unasync_files.call_args_list[0].kwargs["config"]
 
     assert config.transform_docstrings is transform_docstrings
-    assert config.remove_unused_imports is remove_unused_imports
     assert config.add_editors_note is add_editors_note
     assert config.check_only is check_only
     assert config.force_regen is force_regen
@@ -201,12 +195,7 @@ def test_return_code(
 
 
 def test_transform(runner: CliRunner, source_file: Path, target_file: Path) -> None:
-    result = runner.invoke(
-        main,
-        [
-            f"{source_file}:{target_file}",
-        ],
-    )
+    result = runner.invoke(main, [f"{source_file}:{target_file}"])
 
     assert result.exit_code == 1
     assert target_file.read_text() == TEST_TRANSFORMED_CONTENT

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -29,6 +29,7 @@ def test_default_config(config_from_file):
     assert config.files == {}
     assert config.exclude == {}
     assert config.extra_replacements == {}
+    assert config.infer_type_checking_imports is True
 
 
 def test_config_override(config_from_file, tmp_path):
@@ -41,6 +42,7 @@ def test_config_override(config_from_file, tmp_path):
         check_only=True,
         force_regen=True,
         files={"foo.py": "bar.py"},
+        infer_type_checking_imports=False,
     )
 
     assert config.add_editors_note is True
@@ -49,6 +51,7 @@ def test_config_override(config_from_file, tmp_path):
     assert config.check_only is True
     assert config.force_regen is True
     assert config.files == {"foo.py": "bar.py"}
+    assert config.infer_type_checking_imports is False
 
 
 def test_file_directories(config_from_file, tmp_path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -23,7 +23,7 @@ def test_default_config(config_from_file):
 
     assert config.add_editors_note is False
     assert config.transform_docstrings is False
-    assert config.no_cache is False
+    assert config.cache is True
     assert config.check_only is False
     assert config.force_regen is False
     assert config.files == {}
@@ -38,7 +38,7 @@ def test_config_override(config_from_file, tmp_path):
     config = config_from_file(
         add_editors_note=True,
         transform_docstrings=True,
-        no_cache=True,
+        cache=False,
         check_only=True,
         force_regen=True,
         files={"foo.py": "bar.py"},
@@ -47,7 +47,7 @@ def test_config_override(config_from_file, tmp_path):
 
     assert config.add_editors_note is True
     assert config.transform_docstrings is True
-    assert config.no_cache is True
+    assert config.cache is False
     assert config.check_only is True
     assert config.force_regen is True
     assert config.files == {"foo.py": "bar.py"}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -22,7 +22,6 @@ def test_default_config(config_from_file):
     config = config_from_file()
 
     assert config.add_editors_note is False
-    assert config.remove_unused_imports is False
     assert config.transform_docstrings is False
     assert config.no_cache is False
     assert config.check_only is False
@@ -37,7 +36,6 @@ def test_config_override(config_from_file, tmp_path):
 
     config = config_from_file(
         add_editors_note=True,
-        remove_unused_imports=True,
         transform_docstrings=True,
         no_cache=True,
         check_only=True,
@@ -46,7 +44,6 @@ def test_config_override(config_from_file, tmp_path):
     )
 
     assert config.add_editors_note is True
-    assert config.remove_unused_imports is True
     assert config.transform_docstrings is True
     assert config.no_cache is True
     assert config.check_only is True

--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1406,3 +1406,35 @@ def test_honour_type_checking_import_multiple_names_from_same_module() -> None:
     """
     result = transformer(dedent(source))
     assert result == dedent(expected)
+
+
+def test_disable_infer_type_checking_imports() -> None:
+    transformer = TreeTransformer(
+        extra_name_replacements={
+            "module_a.AsyncThing": "module_b.SyncThing",
+        },
+        infer_type_checking_imports=False,
+    )
+
+    source = """
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from module_a import AsyncThing
+
+    def bar() -> AsyncThing:
+        pass
+    """
+
+    expected = """
+    from typing import TYPE_CHECKING
+    from module_b import SyncThing
+
+    if TYPE_CHECKING:
+        from module_a import AsyncThing
+
+    def bar() -> SyncThing:
+        pass
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)

--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -6,14 +6,9 @@ import pytest
 from unasyncd.transformers import TreeTransformer
 
 
-@pytest.fixture(params=[True, False])
-def remove_unused_imports(request) -> bool:
-    return request.param
-
-
 @pytest.fixture
 def transformer() -> TreeTransformer:
-    return TreeTransformer(remove_unused_imports=True)
+    return TreeTransformer()
 
 
 def test_unwrap_name_or_attribute() -> None:
@@ -215,7 +210,7 @@ def test_asynccontextmanager(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from contextlib import contextmanager
+    from contextlib import asynccontextmanager, contextmanager
 
     @contextmanager
     def foo():
@@ -235,7 +230,7 @@ def test_asynccontextmanager_alias_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from contextlib import contextmanager
+    from contextlib import asynccontextmanager as something_else, contextmanager
 
     @contextmanager
     def foo():
@@ -288,7 +283,7 @@ def test_async_generator(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Generator
+    from typing import AsyncGenerator, Generator
     x: Generator
     """
 
@@ -302,7 +297,7 @@ def test_async_generator_annotation(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Generator
+    from typing import AsyncGenerator, Generator
     x: Generator[str, int, None]
     """
 
@@ -334,7 +329,7 @@ def test_async_generator_class(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Generator
+    from typing import AsyncGenerator, Generator
 
     class Foo(Generator[str, int, None]):
         pass
@@ -370,7 +365,7 @@ def test_async_iterable_annotation(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Iterable
+    from typing import AsyncIterable, Iterable
     x: Iterable[str, int]
     """
 
@@ -402,7 +397,7 @@ def test_async_iterable_class(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Iterable
+    from typing import AsyncIterable, Iterable
 
     class Foo(Iterable[str, int]):
         pass
@@ -454,7 +449,7 @@ def test_async_iterator_annotation(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Iterator
+    from typing import AsyncIterator, Iterator
     x: Iterator[str, int]
     """
 
@@ -486,7 +481,7 @@ def test_async_iterator_class(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from typing import Iterator
+    from typing import AsyncIterator, Iterator
 
     class Foo(Iterator[str, int]):
         pass
@@ -527,7 +522,7 @@ def test_async_exit_stack(transformer: TreeTransformer) -> None:
     """
 
     expected = """
-    from contextlib import ExitStack
+    from contextlib import AsyncExitStack, ExitStack
 
     with ExitStack() as some_stack_name:
         some_stack_name.enter_context(foo)
@@ -580,6 +575,7 @@ def test_asyncio_task_group(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from asyncio import TaskGroup
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as some_name:
@@ -607,6 +603,7 @@ def test_asyncio_task_alter_name(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from asyncio import TaskGroup
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as executor:
@@ -628,6 +625,7 @@ def test_asyncio_task_group_alias_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from asyncio import TaskGroup as Foobar
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as executor:
@@ -646,6 +644,7 @@ def test_asyncio_task_group_module_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    import asyncio
     import concurrent.futures
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -727,6 +726,7 @@ def test_anyio_task_group(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from anyio import create_task_group
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as some_name:
@@ -755,6 +755,7 @@ def test_anyio_task_alter_name(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from anyio import create_task_group
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as executor:
@@ -776,6 +777,7 @@ def test_anyio_task_group_alias_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    from anyio import create_task_group as something_else
     from concurrent.futures import ThreadPoolExecutor
 
     with ThreadPoolExecutor() as executor:
@@ -794,6 +796,7 @@ def test_anyio_task_group_module_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    import anyio
     import concurrent.futures
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -837,6 +840,7 @@ def test_asyncio_sleep_module_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    import asyncio
     import time
     time.sleep(1)
     """
@@ -854,6 +858,7 @@ def test_asyncio_sleep_0(transformer: TreeTransformer):
     """
 
     expected = """
+    import asyncio
 
     def foo():
         return True
@@ -868,7 +873,6 @@ def test_anyio_sleep(transformer: TreeTransformer) -> None:
     await sleep(1)
     """
 
-    # these cases are hard and expensive to track, so we just don't
     expected = """
     from anyio import sleep
     from time import sleep
@@ -885,6 +889,7 @@ def test_anyio_sleep_module_import(transformer: TreeTransformer) -> None:
     """
 
     expected = """
+    import anyio
     import time
     time.sleep(1)
     """
@@ -902,6 +907,7 @@ def test_anyio_sleep_0(transformer: TreeTransformer):
     """
 
     expected = """
+    import anyio
 
     def foo():
         return True
@@ -924,8 +930,8 @@ def test_relative_import(transformer: TreeTransformer) -> None:
     assert transformer(dedent(source)) == dedent(expected)
 
 
-def test_add_new_import_with_module_docstring(remove_unused_imports: bool) -> None:
-    transformer = TreeTransformer(remove_unused_imports=remove_unused_imports)
+def test_add_new_import_with_module_docstring() -> None:
+    transformer = TreeTransformer()
 
     source = '''
     """This is a module level docstring"""
@@ -935,31 +941,20 @@ def test_add_new_import_with_module_docstring(remove_unused_imports: bool) -> No
         await asyncio.sleep(1)
     '''
 
-    if remove_unused_imports:
-        expected = '''
-        """This is a module level docstring"""
-        import time
+    expected = '''
+    """This is a module level docstring"""
+    import asyncio
+    import time
 
-        def foo():
-            time.sleep(1)
-        '''
-    else:
-        expected = '''
-        """This is a module level docstring"""
-        import asyncio
-        import time
-
-        def foo():
-            time.sleep(1)
-        '''
+    def foo():
+        time.sleep(1)
+    '''
 
     assert transformer(dedent(source)) == dedent(expected)
 
 
-def test_add_new_import_with_module_docstring_multiline(
-    remove_unused_imports: bool,
-) -> None:
-    transformer = TreeTransformer(remove_unused_imports=remove_unused_imports)
+def test_add_new_import_with_module_docstring_multiline() -> None:
+    transformer = TreeTransformer()
 
     source = '''
     """This is a module level docstring.
@@ -971,35 +966,23 @@ def test_add_new_import_with_module_docstring_multiline(
         await asyncio.sleep(1)
     '''
 
-    if remove_unused_imports:
-        expected = '''
-        """This is a module level docstring.
-        It has multiple lines
-        """
-        import time
+    expected = '''
+    """This is a module level docstring.
+    It has multiple lines
+    """
+    import asyncio
+    import time
 
-        def foo():
-            time.sleep(1)
-        '''
-    else:
-        expected = '''
-        """This is a module level docstring.
-        It has multiple lines
-        """
-        import asyncio
-        import time
-
-        def foo():
-            time.sleep(1)
-        '''
+    def foo():
+        time.sleep(1)
+    '''
 
     assert transformer(dedent(source)) == dedent(expected)
 
 
-def test_type_checking_import(remove_unused_imports: bool) -> None:
+def test_type_checking_import() -> None:
     transformer = TreeTransformer(
         extra_name_replacements={"foo.AsyncThing": "bar.SyncThing"},
-        remove_unused_imports=remove_unused_imports,
     )
 
     source = """
@@ -1012,35 +995,23 @@ def test_type_checking_import(remove_unused_imports: bool) -> None:
         ...
     """
 
-    if remove_unused_imports:
-        expected = """
-        from typing import TYPE_CHECKING
+    expected = """
+    from typing import TYPE_CHECKING
 
-        if TYPE_CHECKING:
-            from bar import SyncThing
+    if TYPE_CHECKING:
+        from foo import AsyncThing
+        from bar import SyncThing
 
-        def func() -> SyncThing:
-            ...
-        """
-    else:
-        expected = """
-        from typing import TYPE_CHECKING
-
-        if TYPE_CHECKING:
-            from foo import AsyncThing
-            from bar import SyncThing
-
-        def func() -> SyncThing:
-            ...
-        """
+    def func() -> SyncThing:
+        ...
+    """
 
     assert transformer(dedent(source)) == dedent(expected)
 
 
-def test_reuse_existing_import(remove_unused_imports: bool) -> None:
+def test_reuse_existing_import() -> None:
     transformer = TreeTransformer(
         extra_name_replacements={"foo.AsyncThing": "bar.SyncThing"},
-        remove_unused_imports=remove_unused_imports,
     )
 
     source = """
@@ -1051,29 +1022,20 @@ def test_reuse_existing_import(remove_unused_imports: bool) -> None:
         ...
     """
 
-    if remove_unused_imports:
-        expected = """
-        from bar import SyncThing
+    expected = """
+    from foo import AsyncThing
+    from bar import SyncThing
 
-        def func() -> SyncThing:
-            ...
-        """
-    else:
-        expected = """
-        from foo import AsyncThing
-        from bar import SyncThing
-
-        def func() -> SyncThing:
-            ...
-        """
+    def func() -> SyncThing:
+        ...
+    """
 
     assert transformer(dedent(source)) == dedent(expected)
 
 
-def test_add_to_existing_from_import(remove_unused_imports: bool) -> None:
+def test_add_to_existing_from_import() -> None:
     transformer = TreeTransformer(
         extra_name_replacements={"foo.async_func": "foo.sync_func"},
-        remove_unused_imports=remove_unused_imports,
     )
     source = """
     from foo import bar, async_func
@@ -1082,27 +1044,18 @@ def test_add_to_existing_from_import(remove_unused_imports: bool) -> None:
         await async_func()
     """
 
-    if remove_unused_imports:
-        expected = """
-        from foo import bar, sync_func
+    expected = """
+    from foo import bar, async_func, sync_func
 
-        def call_func():
-            sync_func()
-        """
-
-    else:
-        expected = """
-        from foo import bar, async_func, sync_func
-
-        def call_func():
-            sync_func()
-        """
+    def call_func():
+        sync_func()
+    """
 
     assert transformer(dedent(source)) == dedent(expected)
 
 
 def test_unused_name_not_replaced() -> None:
-    transformer = TreeTransformer(remove_unused_imports=True)
+    transformer = TreeTransformer()
     source = """
     from typing import AsyncIterable, Union
 
@@ -1110,7 +1063,7 @@ def test_unused_name_not_replaced() -> None:
     """
 
     expected = """
-    from typing import Union, Iterable
+    from typing import AsyncIterable, Union, Iterable
 
     x: Iterable
     """

--- a/unasyncd/cli.py
+++ b/unasyncd/cli.py
@@ -56,6 +56,12 @@ async def _run(*, config: Config, check_only: bool, verbose: bool) -> bool:
     help="Transform module, class, method and function docstrings",
 )
 @click.option(
+    "--no-infer-type-checking-imports",
+    is_flag=True,
+    default=None,
+    help="Don't infer if new imports should go in an if TYPE_CHECKING block",
+)
+@click.option(
     "--add-editors-note",
     is_flag=True,
     default=None,
@@ -86,6 +92,7 @@ def main(
     files: tuple[str, ...],
     no_cache: bool | None,
     transform_docstrings: bool | None,
+    no_infer_type_checking_imports: bool | None,
     check_only: bool,
     add_editors_note: bool | None,
     config_file: Path | None,
@@ -113,6 +120,9 @@ def main(
         files=dict(f.split(":", 1) for f in files) if files else None,
         check_only=check_only,
         force_regen=force_regen,
+        infer_type_checking_imports=False
+        if no_infer_type_checking_imports is not None
+        else None,
     )
 
     if not config.files:

--- a/unasyncd/cli.py
+++ b/unasyncd/cli.py
@@ -1,14 +1,9 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import rich
-
-if TYPE_CHECKING:
-    import click
-else:
-    import rich_click as click
+import rich_click as click
 
 from .config import Config, load_config
 from .main import unasync_files

--- a/unasyncd/cli.py
+++ b/unasyncd/cli.py
@@ -53,15 +53,7 @@ async def _run(*, config: Config, check_only: bool, verbose: bool) -> bool:
     "--transform-docstrings",
     is_flag=True,
     default=None,
-    help="Transform module, class, method and function docstrings. CST mode only",
-)
-@click.option(
-    "-i",
-    "--remove-unused-imports",
-    is_flag=True,
-    default=None,
-    help="Remove imports that are unused as a result of the transformation. CST mode "
-    "only",
+    help="Transform module, class, method and function docstrings",
 )
 @click.option(
     "--add-editors-note",
@@ -94,7 +86,6 @@ def main(
     files: tuple[str, ...],
     no_cache: bool | None,
     transform_docstrings: bool | None,
-    remove_unused_imports: bool | None,
     check_only: bool,
     add_editors_note: bool | None,
     config_file: Path | None,
@@ -118,7 +109,6 @@ def main(
         path=config_file,
         no_cache=no_cache,
         transform_docstrings=transform_docstrings,
-        remove_unused_imports=remove_unused_imports,
         add_editors_note=add_editors_note,
         files=dict(f.split(":", 1) for f in files) if files else None,
         check_only=check_only,

--- a/unasyncd/config.py
+++ b/unasyncd/config.py
@@ -11,7 +11,7 @@ import msgspec
 class Config(msgspec.Struct):
     add_editors_note: bool
     transform_docstrings: bool
-    no_cache: bool
+    cache: bool
     extra_replacements: dict[str, dict[str, str]]
     exclude: dict[str, list[str]]
     files: dict[str, str]
@@ -70,7 +70,7 @@ def load_config(path: Path | None, **defaults: Any) -> Config:
         },
         add_editors_note=raw_config.get("add_editors_note", False),
         transform_docstrings=raw_config.get("transform_docstrings", False),
-        no_cache=raw_config.get("no_cache", False),
+        cache=raw_config.get("cache", True),
         check_only=raw_config.get("check_only", False),
         force_regen=raw_config.get("force_regen", False),
         infer_type_checking_imports=raw_config.get("infer_type_checking_imports", True),

--- a/unasyncd/config.py
+++ b/unasyncd/config.py
@@ -11,7 +11,6 @@ import msgspec
 class Config(msgspec.Struct):
     add_editors_note: bool
     transform_docstrings: bool
-    remove_unused_imports: bool
     no_cache: bool
     extra_replacements: dict[str, dict[str, str]]
     exclude: dict[str, list[str]]
@@ -69,7 +68,6 @@ def load_config(path: Path | None, **defaults: Any) -> Config:
             for file in itertools.chain(files, per_file_exclude)
         },
         add_editors_note=raw_config.get("add_editors_note", False),
-        remove_unused_imports=raw_config.get("remove_unused_imports", False),
         transform_docstrings=raw_config.get("transform_docstrings", False),
         no_cache=raw_config.get("no_cache", False),
         check_only=raw_config.get("check_only", False),

--- a/unasyncd/config.py
+++ b/unasyncd/config.py
@@ -17,6 +17,7 @@ class Config(msgspec.Struct):
     files: dict[str, str]
     force_regen: bool
     check_only: bool
+    infer_type_checking_imports: bool
 
     def key(self) -> str:
         return hashlib.sha1(msgspec.json.encode(self)).hexdigest()
@@ -72,4 +73,5 @@ def load_config(path: Path | None, **defaults: Any) -> Config:
         no_cache=raw_config.get("no_cache", False),
         check_only=raw_config.get("check_only", False),
         force_regen=raw_config.get("force_regen", False),
+        infer_type_checking_imports=raw_config.get("infer_type_checking_imports", True),
     )

--- a/unasyncd/main.py
+++ b/unasyncd/main.py
@@ -177,6 +177,7 @@ class Env:
             exclude=self.config.exclude.get(str(file), set()),
             transform_docstrings=self.config.transform_docstrings,
             extra_name_replacements=self.config.extra_replacements.get(str(file), {}),
+            infer_type_checking_imports=self.config.infer_type_checking_imports,
         )
 
         content = await file.get_content()

--- a/unasyncd/main.py
+++ b/unasyncd/main.py
@@ -247,7 +247,7 @@ class Env:
                 source=source_file, target=target_file, transformed=False
             )
 
-        if not self.config.no_cache:
+        if self.config.cache:
             if await self._restore_from_cache(source_file, target_file):
                 return TransformationResult(
                     source=source_file, target=target_file, transformed=True
@@ -275,7 +275,7 @@ class Env:
 
             await self.set_meta(target_file)
 
-        if not self.config.no_cache:
+        if self.config.cache:
             await self.cache.set(
                 await self._cache_key_for(source_file), transformed_content
             )

--- a/unasyncd/main.py
+++ b/unasyncd/main.py
@@ -176,7 +176,6 @@ class Env:
         transformer = TreeTransformer(
             exclude=self.config.exclude.get(str(file), set()),
             transform_docstrings=self.config.transform_docstrings,
-            remove_unused_imports=self.config.remove_unused_imports,
             extra_name_replacements=self.config.extra_replacements.get(str(file), {}),
         )
 

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import re
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import libcst as cst
@@ -49,19 +49,18 @@ UNASYNC_REPLACEMENTS = {
 ASYNC_GEN_RE = re.compile(r"AsyncGenerator\[(.+,.+)]")
 
 
-@dataclass
+@dataclasses.dataclass
 class TransformerMeta:
-    module_imports: dict[str, AnyImport]
     needs_from_import: defaultdict[str, set[str]]
     needs_module_import: set[str]
     exclude: set[tuple[str, ...]]
     removed_names: defaultdict[str, set[str]]
 
 
-@dataclass
+@dataclasses.dataclass
 class ImportMeta:
-    module_imports: dict[str, cst.Import]
-    from_imports: dict[str, cst.ImportFrom]
+    module_imports: dict[str, cst.Import] = dataclasses.field(default_factory=dict)
+    from_imports: dict[str, cst.ImportFrom] = dataclasses.field(default_factory=dict)
 
 
 class StringTransformer:
@@ -128,6 +127,21 @@ def _get_docstring_node(
         return val
 
     return None
+
+
+def _get_full_name_for_import_from(node: cst.ImportFrom) -> str:
+    return (
+        cst.helpers.get_full_name_for_node_or_raise(node.module)
+        if node.module
+        else "." * len(node.relative)
+    )
+
+
+def _create_import_from(module_name: str, names: Iterable[str]) -> cst.ImportFrom:
+    return cst.ImportFrom(
+        module=_create_name_or_attr(module_name),
+        names=[cst.ImportAlias(cst.Name(name)) for name in names],
+    )
 
 
 class TreeTransformer:
@@ -372,29 +386,56 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
             become unused due to the transformation
         """
         super().__init__()
-        self._current_scop_name: tuple[str, ...] = tuple()
-        self._name_replacements = name_replacements
+        self._should_remove_unused_imports = remove_unused_imports
         self._should_transform_docstrings = transform_docstrings
-        self.meta = TransformerMeta(
-            module_imports={},
-            needs_from_import=defaultdict(set),
-            exclude={tuple(p.split(".")) for p in exclude or []},
-            removed_names=defaultdict(set),
-            needs_module_import=set(),
-        )
-        self._in_import = False
-        self.attribute_replacements = {
+        self._name_replacements = name_replacements
+        self._attribute_replacements = {
             name: replacement
             for name, replacement in name_replacements.items()
             if "." in name
         }
-        self.expressions_to_remove: set[cst.Expr] = set()
-        self.scoped_node_imports: defaultdict[cst.CSTNode, ImportMeta] = defaultdict(
+
+        self._scoped_node_imports: defaultdict[cst.CSTNode, ImportMeta] = defaultdict(
             lambda: ImportMeta(module_imports={}, from_imports={})
         )
-        self._scope_nodes: list[cst.CSTNode] = []
-        self.remove_unused_imports = remove_unused_imports
+
+        self._expressions_to_remove: set[cst.Expr] = set()
         self._string_transformer = StringTransformer()
+
+        self._current_scop_name: tuple[str, ...] = tuple()
+        self._scope_nodes: list[cst.CSTNode] = []
+
+        self._if_type_checking_node: cst.If | None = None
+        self._if_type_checking_imports: set[AnyImport] = set()
+        self._in_if_type_checking_block: bool = False
+        self._in_import = False
+
+        self.meta = TransformerMeta(
+            needs_from_import=defaultdict(set),
+            needs_module_import=set(),
+            removed_names=defaultdict(set),
+            exclude={tuple(p.split(".")) for p in exclude or []},
+        )
+
+    def visit_If(self, node: cst.If) -> bool | None:
+        if (
+            isinstance(node.test, cst.Name)
+            and self.get_qualified_name(node.test) == "typing.TYPE_CHECKING"
+        ):
+            self._if_type_checking_node = node
+            self._in_if_type_checking_block = True
+
+        return None
+
+    def leave_If(self, original_node: cst.If, updated_node: cst.If) -> Any:
+        if original_node is self._if_type_checking_node:
+            self._in_if_type_checking_block = False
+
+            # replace with the updated node, so we can check for identity later on when
+            # performing transformations
+            self._if_type_checking_node = updated_node
+
+        return updated_node
 
     @property
     def current_scope_node(self) -> cst.CSTNode | None:
@@ -492,6 +533,34 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
 
         return updated_node
 
+    def _register_import(self, node: cst.Import | cst.ImportFrom) -> None:
+        if not self.current_scope_node:
+            return
+
+        node_imports = self._scoped_node_imports[self.current_scope_node]
+        if isinstance(node, cst.Import):
+            for name in node.names:
+                node_imports.module_imports[name.evaluated_name] = node
+            return None
+
+        module_name = _get_full_name_for_import_from(node)
+        node_imports.from_imports[module_name] = node
+
+    def _leave_any_import(
+        self, original_node: AnyImport, updated_node: AnyImport
+    ) -> (
+        cst.BaseSmallStatement
+        | cst.FlattenSentinel[cst.BaseSmallStatement]
+        | cst.RemovalSentinel
+    ):
+        self._in_import = False
+
+        self._register_import(updated_node)
+        if self._in_if_type_checking_block:
+            self._if_type_checking_imports.add(updated_node)
+
+        return updated_node
+
     def visit_ImportFrom(self, node: cst.ImportFrom) -> bool:
         self._in_import = True
         return True
@@ -507,9 +576,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         | cst.FlattenSentinel[cst.BaseSmallStatement]
         | cst.RemovalSentinel
     ):
-        self._in_import = False
-        self.register_import(updated_node)
-        return updated_node
+        return self._leave_any_import(original_node, updated_node)
 
     def leave_Import(
         self, original_node: cst.Import, updated_node: cst.Import
@@ -518,26 +585,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         | cst.FlattenSentinel[cst.BaseSmallStatement]
         | cst.RemovalSentinel
     ):
-        self._in_import = False
-        self.register_import(updated_node)
-        return updated_node
-
-    def register_import(self, node: cst.Import | cst.ImportFrom) -> None:
-        if not self.current_scope_node:
-            return
-
-        node_imports = self.scoped_node_imports[self.current_scope_node]
-        if isinstance(node, cst.Import):
-            for name in node.names:
-                node_imports.module_imports[name.evaluated_name] = node
-            return None
-
-        module_name = (
-            cst.helpers.get_full_name_for_node_or_raise(node.module)
-            if node.module
-            else "." * len(node.relative)
-        )
-        node_imports.from_imports[module_name] = node
+        return self._leave_any_import(original_node, updated_node)
 
     def leave_Attribute(
         self, original_node: cst.Attribute, updated_node: cst.Attribute
@@ -545,7 +593,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         if not (qualified_name := self.get_qualified_name(original_node)):
             return updated_node
 
-        if not (replacement := self.attribute_replacements.get(qualified_name)):
+        if not (replacement := self._attribute_replacements.get(qualified_name)):
             return updated_node
 
         module_name, attr = qualified_name.rsplit(".", 1)
@@ -661,7 +709,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
             if m.matches(
                 call, m.Call(args=[m.AtLeastN(m.Arg(m.Integer(value="0")), n=1)])
             ):
-                self.expressions_to_remove.add(node)
+                self._expressions_to_remove.add(node)
                 removed_mod, removed_name = qualified_name.split(".")
                 self.meta.removed_names[removed_mod].add(removed_name)
                 return False
@@ -671,7 +719,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         self, original_node: cst.Expr, updated_node: cst.Expr
     ) -> cst.BaseSmallStatement | cst.RemovalSentinel:
         """Remove expressions registered to be removed"""
-        if original_node in self.expressions_to_remove:
+        if original_node in self._expressions_to_remove:
             return cst.RemoveFromParent()
         return updated_node
 
@@ -786,12 +834,31 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
                 return i
         return 0
 
+    def _extract_if_type_checking_imports(
+        self, existing_imports: dict[str, AnyImportT]
+    ) -> dict[str, set[str]]:
+        type_checking_imports: dict[str, set[str]] = defaultdict(set)
+        for module_name, import_ in existing_imports.items():
+            if import_ not in self._if_type_checking_imports:
+                continue
+            if not isinstance(import_.names, cst.ImportStar):
+                type_checking_imports[module_name].update(
+                    [n.evaluated_alias or n.evaluated_name for n in import_.names]
+                )
+        return type_checking_imports
+
     def _create_from_imports(
-        self, existing_from_imports: dict[str, cst.ImportFrom]
+        self,
+        existing_from_imports: dict[str, cst.ImportFrom],
+        replaced_names: dict[str, dict[str, str]],
+        new_type_checking_imports: set[AnyImport],
     ) -> tuple[dict[cst.ImportFrom, set[str]], list[cst.ImportFrom]]:
         """Return a tuple of ``FromImport``s to update and ``FromImport``s to add"""
         from_imports_to_update: defaultdict[cst.ImportFrom, set[str]] = defaultdict(set)
         from_imports_to_add: defaultdict[str, set[str]] = defaultdict(set)
+        existing_if_type_checking_imports = self._extract_if_type_checking_imports(
+            existing_from_imports
+        )
 
         for module_name, names in self.meta.needs_from_import.items():
             if _import := existing_from_imports.get(module_name):
@@ -805,25 +872,72 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
             else:
                 from_imports_to_add[module_name].update(names)
 
-        new_from_imports = [
-            cst.ImportFrom(
-                module=_create_name_or_attr(module_name),
-                names=[cst.ImportAlias(cst.Name(name)) for name in names],
-            )
-            for module_name, names in from_imports_to_add.items()
-        ]
-        return from_imports_to_update, new_from_imports
+        new_imports = []
+        for module_name, names in from_imports_to_add.items():
+            new_import_names = set()
+            new_type_checking_import_names = set()
+
+            if replaced_imports := replaced_names.get(module_name):
+                # we have replaced names, so we check for the ones that exist
+                # exclusively within an if TYPE_CHECKING block to ensure we only add
+                # those there
+                for new_name in names:
+                    original_fq_name = replaced_imports[new_name]
+                    orig_module_name, orig_name = original_fq_name.rsplit(".", 1)
+                    if orig_name in existing_if_type_checking_imports.get(
+                        orig_module_name, []
+                    ):
+                        new_type_checking_import_names.add(new_name)
+                    else:
+                        new_import_names.add(new_name)
+            else:
+                new_import_names.update(names)
+
+            if new_import_names:
+                new_imports.append(_create_import_from(module_name, new_import_names))
+
+            if new_type_checking_import_names:
+                new_type_checking_imports.add(
+                    _create_import_from(module_name, new_type_checking_import_names)
+                )
+
+        return from_imports_to_update, new_imports
 
     def _create_module_imports(
-        self, existing_module_import: dict[str, cst.Import]
-    ) -> list[cst.Import]:
+        self,
+        existing_module_imports: dict[str, cst.Import],
+        replaced_names: dict[str, dict[str, str]],
+        type_checking_imports: set[AnyImport],
+    ) -> set[cst.Import]:
         """Return a list of ``Import``s to add"""
-        return [
-            cst.Import(names=[cst.ImportAlias(name=_create_name_or_attr(module_name))])
-            for module_name in self.meta.needs_module_import
-            if not (_import := existing_module_import.get(module_name))
-            and not isinstance(_import, cst.ImportFrom)
-        ]
+        new_imports: set[cst.Import] = set()
+        existing_tc_import = self._extract_if_type_checking_imports(
+            existing_module_imports
+        )
+        for module_name in self.meta.needs_module_import:
+            if _import := existing_module_imports.get(module_name):
+                continue
+
+            if isinstance(_import, cst.ImportFrom):
+                continue
+
+            new_import = cst.Import(
+                names=[cst.ImportAlias(name=_create_name_or_attr(module_name))]
+            )
+
+            maybe_replaced_imports = replaced_names.get(module_name)
+            if not maybe_replaced_imports:
+                new_imports.add(new_import)
+                continue
+
+            for new_name, original_fq_name in maybe_replaced_imports.items():
+                orig_module_name, _ = original_fq_name.rsplit(".", 1)
+                if orig_module_name in existing_tc_import:
+                    type_checking_imports.add(new_import)
+                else:
+                    new_imports.add(new_import)
+
+        return new_imports
 
     def _fix_module_imports(
         self,
@@ -841,27 +955,46 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         - Remove names from imports specified in ``imports_to_remove``. If an import has
           no names left, it is removed entirely
         """
+        maybe_replaced_names: dict[str, dict[str, str]] = defaultdict(dict)
+        add_to_typechecking_import: set[AnyImport] = set()
+
+        for name, replacement in self._name_replacements.items():
+            if "." not in name:
+                continue
+            module_name, replacement = replacement.rsplit(".", 1)
+            maybe_replaced_names[module_name][replacement] = name
+
         from_imports_to_update, new_from_imports = self._create_from_imports(
-            from_imports
+            from_imports,
+            replaced_names=maybe_replaced_names,
+            new_type_checking_imports=add_to_typechecking_import,
+        )
+        new_module_imports = self._create_module_imports(
+            module_imports,
+            replaced_names=maybe_replaced_names,
+            type_checking_imports=add_to_typechecking_import,
         )
 
         updated_node = node.visit(
             _ImportTransformer(
                 unused_imports=imports_to_remove,
                 imports_to_update=from_imports_to_update,
+                if_type_checking_node=self._if_type_checking_node,
+                type_checking_imports_to_add=add_to_typechecking_import,
             )
         )
 
-        new_module_imports = self._create_module_imports(module_imports)
         import_offset = self._find_first_non_import_line(updated_node)
+
         new_module_body = [
             *updated_node.body[:import_offset],
             *[
-                cst.SimpleStatementLine(body=[new_import])
-                for new_import in itertools.chain(new_module_imports, new_from_imports)
+                cst.SimpleStatementLine([new_import])
+                for new_import in itertools.chain(new_from_imports, new_module_imports)
             ],
             *updated_node.body[import_offset:],
         ]
+
         updated_node = updated_node.with_changes(body=new_module_body)
 
         if self._should_transform_docstrings and self._should_transform_current_node:
@@ -872,7 +1005,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
     def leave_Module(
         self, original_node: cst.Module, updated_node: cst.Module
     ) -> cst.Module:
-        if self.remove_unused_imports and self.meta.removed_names:
+        if self._should_remove_unused_imports and self.meta.removed_names:
             wrapper = MetadataWrapper(updated_node)
             (
                 module_imports,
@@ -886,7 +1019,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
                 imports_to_remove=imports_to_remove,
             )
 
-        import_meta = self.scoped_node_imports[original_node]
+        import_meta = self._scoped_node_imports[original_node]
         return self._fix_module_imports(
             node=updated_node,
             module_imports=import_meta.module_imports,
@@ -896,7 +1029,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
 
 
 class _ImportTransformer(cst.CSTTransformer):
-    # taken from
+    # partly taken from
     # https://cst.readthedocs.io/en/latest/scope_tutorial.html#Automatically-Remove-Unused-Import
 
     def __init__(
@@ -904,10 +1037,36 @@ class _ImportTransformer(cst.CSTTransformer):
         *,
         unused_imports: dict[AnyImport, set[str]],
         imports_to_update: dict[cst.ImportFrom, set[str]],
+        if_type_checking_node: cst.If | None,
+        type_checking_imports_to_add: Iterable[AnyImport],
     ) -> None:
         super().__init__()
         self.unused_imports = unused_imports
         self.imports_to_update = imports_to_update
+        self.if_type_checking_node = if_type_checking_node
+        self.type_checking_imports_to_add = type_checking_imports_to_add
+
+    def leave_If(
+        self, original_node: cst.If, updated_node: cst.If
+    ) -> (
+        cst.BaseStatement | cst.FlattenSentinel[cst.BaseStatement] | cst.RemovalSentinel
+    ):
+        if not self.if_type_checking_node:
+            return updated_node
+
+        if original_node is not self.if_type_checking_node:
+            return updated_node
+
+        return updated_node.with_deep_changes(
+            updated_node.body,
+            body=[
+                *updated_node.body.body,
+                *[
+                    cst.SimpleStatementLine([import_])
+                    for import_ in self.type_checking_imports_to_add
+                ],
+            ],
+        )
 
     def leave_import_alike(
         self, original_node: AnyImportT, updated_node: AnyImportT


### PR DESCRIPTION
- Add support for `if TYPE_CHECKING` imports; Replaced import names now get correctly written back into a `if TYPE_CHECKING` block if the replaced name was originally imported there
- Add feature flag  `infer_type_checking_imports` to control the newly added behaviour
- Add CLI flag `--infer-type-checking-imports` / `--no-infer-type-checking-imports` corresponding to the feature flag
- Remove feature to remove unused imports. This was largely a leftover feature from the tool `unasyncd` was extracted from and since it was making the new `TYPE_CHECKING` feature much more costly and its usage generally discouraged it seemed like the best option to remove it outright
- Add missing CLI feature flags
- Add [rich-click](https://github.com/ewels/rich-click) for a nicer CLI