### PR TITLE
Preserve import formatting

### DIFF
--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1438,3 +1438,14 @@ def test_disable_infer_type_checking_imports() -> None:
     """
 
     assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_preserve_import_formatting(transformer: TreeTransformer) -> None:
+    source = """
+    from typing import (
+        AsyncGenerator,
+        Generator,
+    )
+    """
+
+    assert transformer(dedent(source)) == dedent(source)

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -956,9 +956,6 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
 
 
 class _ImportTransformer(cst.CSTTransformer):
-    # partly taken from
-    # https://cst.readthedocs.io/en/latest/scope_tutorial.html#Automatically-Remove-Unused-Import
-
     def __init__(
         self,
         *,
@@ -993,26 +990,6 @@ class _ImportTransformer(cst.CSTTransformer):
             ],
         )
 
-    def leave_import_alike(
-        self, original_node: AnyImportT, updated_node: AnyImportT
-    ) -> AnyImportT | cst.RemovalSentinel:
-        if isinstance(updated_node.names, cst.ImportStar):
-            return updated_node
-
-        names_to_keep = []
-        for name in updated_node.names:
-            names_to_keep.append(name.with_changes(comma=cst.MaybeSentinel.DEFAULT))
-
-        if len(names_to_keep) == 0:
-            return cst.RemoveFromParent()
-        else:
-            return updated_node.with_changes(names=names_to_keep)  # type: ignore[return-value]  # noqa: E501
-
-    def leave_Import(
-        self, original_node: cst.Import, updated_node: cst.Import
-    ) -> cst.Import | cst.RemovalSentinel:
-        return self.leave_import_alike(original_node, updated_node)
-
     def leave_ImportFrom(
         self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> cst.ImportFrom | cst.RemovalSentinel:
@@ -1030,7 +1007,7 @@ class _ImportTransformer(cst.CSTTransformer):
                 names=[*current_names, *new_aliases]
             )
 
-        return self.leave_import_alike(original_node, updated_node)
+        return updated_node
 
     # since we're only interested in module level imports, we don't need to visit
     # class and function definitions


### PR DESCRIPTION
Fix a bug where import formatting was not preserved in some cases.

```python
from typing import (
    AsyncGenerator,
    Generator,
)
```

would become

```python
from typing import (
    AsyncGenerator, Generator,)
```