### PR TITLE
Support for asynchronous comprehensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ for x in foo():
     pass
 ```
 
+*Async*
+```python
+[x async for x in foo()]
+```
+
+*Sync*
+```python
+[x for x in foo()]
+```
+
 ### Asynchronous context managers
 
 *Async*

--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1470,3 +1470,21 @@ def test_ruff_fix(tmp_path, monkeypatch) -> None:
     """
 
     assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_async_comprehension(transformer: TreeTransformer) -> None:
+    source = """
+    [x async for x in foo()]
+    {x async for x in foo()}
+    (x async for x in foo())
+    {x: 1 async for x in foo()}
+    """
+
+    expected = """
+    [x for x in foo()]
+    {x for x in foo()}
+    (x for x in foo())
+    {x: 1 for x in foo()}
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -765,6 +765,13 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
             updated_node = updated_node.with_changes(asynchronous=None)
         return updated_node
 
+    def leave_CompFor(
+        self, original_node: cst.CompFor, updated_node: cst.CompFor
+    ) -> cst.CompFor:
+        if updated_node.asynchronous:
+            updated_node = updated_node.with_changes(asynchronous=None)
+        return updated_node
+
     def leave_Subscript(
         self, original_node: cst.Subscript, updated_node: cst.Subscript
     ) -> cst.Subscript:


### PR DESCRIPTION
Add support for transforming asynchronous comprehensions (`[x async for x in foo]`).