### PR TITLE
Fix replacing names to relative modules with other relative names

### DIFF
--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1488,3 +1488,25 @@ def test_async_comprehension(transformer: TreeTransformer) -> None:
     """
 
     assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_replace_relative_imported_names() -> None:
+    transformer = TreeTransformer(
+        extra_name_replacements={".foo.AsyncThing": ".bar.SyncThing"}
+    )
+    source = """
+    from .foo import AsyncThing
+
+    async def func() -> AsyncThing:
+        ...
+    """
+
+    expected = """
+    from .foo import AsyncThing
+    from .bar import SyncThing
+
+    def func() -> SyncThing:
+        ...
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -90,6 +90,7 @@ def _create_name_or_attr(qualified_name: str) -> cst.Attribute | cst.Name:
     """Create a name or attribute from a fully qualified name"""
     if "." in qualified_name:
         attributes, qualified_name = qualified_name.rsplit(".", 1)
+        # if attributes:
         return cst.Attribute(
             attr=cst.Name(value=qualified_name), value=_create_name_or_attr(attributes)
         )
@@ -142,9 +143,15 @@ def _get_full_name_for_import_from(node: cst.ImportFrom) -> str:
 
 
 def _create_import_from(module_name: str, names: Iterable[str]) -> cst.ImportFrom:
+    relative: list[cst.Dot] = []
+    if "." in module_name:
+        orig_len = len(module_name)
+        module_name = module_name.lstrip(".")
+        relative = [cst.Dot() for _ in range(orig_len - len(module_name))]
     return cst.ImportFrom(
         module=_create_name_or_attr(module_name),
         names=[cst.ImportAlias(cst.Name(name)) for name in names],
+        relative=relative,
     )
 
 


### PR DESCRIPTION
Fix a bug that would cause an exception to be raised when a name from a relative import was configured to be replaced with another name from a relative import (e.g. `from .foo import AsyncThing` > `from .bar import SyncThing`).