### PR TITLE
Add support for `anyio.Path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,22 @@ import asyncio
 await asyncio.sleep(0)
 ```
 
+### `anyio.Path`
+
+*Async*
+```python
+import anyio
+
+await anyio.Path().read_bytes()
+```
+
+*Sync*
+```python
+import pathlib
+
+pathlib.Path().read_bytes()
+```
+
 ### Type annotations
 
 |                                   |                                    |

--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1536,3 +1536,37 @@ def test_module_dunder_all_import():
     """
 
     assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_anyio_path(transformer):
+    source = """
+    from anyio import Path
+
+    foo = await Path().read_text()
+    """
+
+    expected = """
+    from anyio import Path
+    from pathlib import Path
+
+    foo = Path().read_text()
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_anyio_path_module_import(transformer):
+    source = """
+    import anyio
+
+    foo = await anyio.Path().read_text()
+    """
+
+    expected = """
+    import anyio
+    import pathlib
+
+    foo = pathlib.Path().read_text()
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -38,6 +38,7 @@ NAME_REPLACEMENTS = {
     "typing.AsyncGenerator": "typing.Generator",
     "asyncio.sleep": "time.sleep",
     "anyio.sleep": "time.sleep",
+    "anyio.Path": "pathlib.Path",
 }
 
 


### PR DESCRIPTION
Add support for transforming `anyio.Path` to `pathlib.Path`.

*Async*
```python
import anyio

await anyio.Path().read_bytes()
```

*Sync*
```python
import pathlib

pathlib.Path().read_bytes()
```