### PR TITLE
Invalidate cache when package version has changed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -123,6 +123,25 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "6.8.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_metadata-6.8.0-py3-none-any.whl", hash = "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"},
+    {file = "importlib_metadata-6.8.0.tar.gz", hash = "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -603,10 +622,25 @@ platformdirs = ">=3.5.1,<4"
 docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
 
+[[package]]
+name = "zipp"
+version = "3.16.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.16.2-py3-none-any.whl", hash = "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0"},
+    {file = "zipp-3.16.2.tar.gz", hash = "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
+
 [extras]
 ruff = ["ruff"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "db912c93f79b369ef511f8f4deba706615eef7eab7c40b578190b868a200bf0d"
+content-hash = "99a9ad4efad5f3c396b333ab553cf8148f675b07a748f01fa5e51cf40e922f89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ msgspec = "^0.17.0"
 tomli-w = "^1.0.0"
 rich-click = "^1.6.1"
 ruff = {version = "*", optional = true}
+importlib-metadata = { version = "^6.8.0", python = "<3.10" }
+
 
 [tool.poetry.extras]
 ruff = ["ruff"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -122,3 +122,14 @@ def test_config_key(config_from_file):
     old_key = config.key()
     config.force_regen = True
     assert config.key() != old_key
+
+
+def test_config_key_changes_with_version(config_from_file, monkeypatch):
+    config = config_from_file()
+    old_key = config.key()
+
+    import unasyncd.config
+
+    monkeypatch.setattr(unasyncd.config, "VERSION", "99.0.0")
+
+    assert old_key != config.key()

--- a/unasyncd/_version.py
+++ b/unasyncd/_version.py
@@ -1,0 +1,9 @@
+import sys
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+VERSION = importlib_metadata.version("unasyncd")

--- a/unasyncd/config.py
+++ b/unasyncd/config.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import msgspec
 
+from ._version import VERSION
+
 
 class Config(msgspec.Struct):
     add_editors_note: bool
@@ -21,7 +23,7 @@ class Config(msgspec.Struct):
     ruff_fix: bool
 
     def key(self) -> str:
-        return hashlib.sha1(msgspec.json.encode(self)).hexdigest()
+        return hashlib.sha1(msgspec.json.encode(self) + VERSION.encode()).hexdigest()
 
 
 def _collect_paths(file_names: dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
Fix an error where incompatible files would be retrieved from the cache after unasyncd has been updated, by taking the installed package version into account when evaluating the cache keys.