### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: "3.11"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -11,18 +11,18 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.290"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
     hooks:
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.4.2
     hooks:
       - id: black
         args: [--config=./pyproject.toml]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.5.1"
+    rev: v1.10.1
     hooks:
       - id: mypy
         exclude: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ unasyncd = "unasyncd.cli:main"
 
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",  # pycodestyle
     "F",  # pyflakes
     "ERA", # eradicate

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -674,7 +674,7 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         ):
             return updated_node
 
-        item_call_func: cst.Attribute | cst.Name = with_item.item.func  # type: ignore[attr-defined]  # noqa: E501
+        item_call_func: cst.Attribute | cst.Name = with_item.item.func  # type: ignore[attr-defined]
 
         if not (scope := self.get_metadata(ScopeProvider, original_node)):
             raise RuntimeError("Scope not found")
@@ -823,11 +823,11 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
 
             for name in import_.names:
                 full_name = name.evaluated_alias or name.evaluated_name
-                imported_names[
-                    full_name
-                ] = f"{_get_full_name_for_import_from(import_)}.{full_name}"
+                imported_names[full_name] = (
+                    f"{_get_full_name_for_import_from(import_)}.{full_name}"
+                )
 
-        elements: list[cst.Element] = updated_node.value.elements  # type: ignore[attr-defined]  # noqa: E501
+        elements: list[cst.Element] = updated_node.value.elements  # type: ignore[attr-defined]
         updated_elements: list[cst.Element] = []
         for element in elements:
             if not isinstance(element.value, cst.SimpleString):


### PR DESCRIPTION
This PR updates your defined pre-commit hooks. Also the recommended repo for ruff is now: `https://github.com/astral-sh/ruff-pre-commit`.