### PR TITLE
docs: fix duplicate entry in tool.unasyncd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,6 @@ per_file_add_replacements = { "async_thing.py" = { "AsyncClass" = "SyncClass" } 
 transform_docstrings = true
 remove_unused_imports = false
 no_cache = false
-no_cache = false
 force_regen = false
 ```
 


### PR DESCRIPTION
This PR removes a duplicate entry in the `[tool.unasyncd]` example. I copy-pasted the example and VS code complained.

Is there another setting, that was meant instead?