### PR TITLE
Fix deprecated 'ruff' command

### DIFF
--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1472,6 +1472,21 @@ def test_ruff_fix(tmp_path, monkeypatch) -> None:
     assert transformer(dedent(source)) == dedent(expected)
 
 
+def test_ruff_fix_ruff_error_raises(tmp_path, monkeypatch) -> None:
+    config_file = tmp_path / "ruff.toml"
+    monkeypatch.chdir(tmp_path)
+    config_file.write_text(tomli_w.dumps({"select": ["FOO017"]}))
+    monkeypatch.chdir(tmp_path)
+    transformer = TreeTransformer(ruff_fix=True)
+
+    source = """
+    import asyncio
+    """
+
+    with pytest.raises(ChildProcessError, match="Error calling ruff"):
+        transformer(dedent(source))
+
+
 def test_async_comprehension(transformer: TreeTransformer) -> None:
     source = """
     [x async for x in foo()]

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -185,6 +185,7 @@ class TreeTransformer:
                 sys.executable,
                 "-m",
                 "ruff",
+                "check",
                 "--no-cache",
                 "--fix",
                 "--quiet",
@@ -195,7 +196,10 @@ class TreeTransformer:
             stdin=subprocess.PIPE,
             encoding="utf-8",
         ) as process:
-            return process.communicate(input=output)[0]
+            stdout, stderr = process.communicate(input=output)
+            if process.returncode != 0:
+                raise ChildProcessError(f"Error calling ruff: {stderr}")
+            return stdout
 
     def __call__(self, source: str) -> str:
         if not source:


### PR DESCRIPTION
When using the `ruff-fix` option, unasyncd would try to invoke ruff using `ruff` directly instead of `ruff check`. This would cause an exception because this style of calling has been removed in newer ruff versions.