### PR TITLE
fix(ruff): Pass filename to ruff when using `--ruff-fix`

### DIFF
--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -1486,6 +1486,27 @@ def test_ruff_fix_ruff_error_raises(tmp_path, monkeypatch) -> None:
         transformer(dedent(source))
 
 
+def test_ruff_fix_pass_file_name(tmp_path, monkeypatch) -> None:
+    config_file = tmp_path / "ruff.toml"
+    config_file.write_text(
+        tomli_w.dumps(
+            {"select": ["I001"], "per-file-ignores": {"some_file.py": ["I001"]}}
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    transformer = TreeTransformer(ruff_fix=True, file_name="some_file.py")
+
+    source = """
+    import time, asyncio
+    """
+
+    expected = """
+    import time, asyncio
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
 def test_async_comprehension(transformer: TreeTransformer) -> None:
     source = """
     [x async for x in foo()]

--- a/unasyncd/main.py
+++ b/unasyncd/main.py
@@ -258,6 +258,7 @@ class Env:
             extra_name_replacements=self.config.extra_replacements.get(str(file), {}),
             infer_type_checking_imports=self.config.infer_type_checking_imports,
             ruff_fix=self.config.ruff_fix,
+            file_name=str(file),
         )
 
         content = await file.get_content()


### PR DESCRIPTION
When using `--ruff-fix` / `ruff_fix = true`, unasyncd passes its transformed content via stdin to ruff. This means that file specific configurations are not respected by ruff, resulting in unwanted errors / fixes by ruff, compared to when it is invoked outside of unasyncd.

The fix for this is to use ruff's `--stdin-filename` argument, to provide the respective file name.