### PR TITLE
Support for `collections.abc` imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,16 @@ pathlib.Path().read_bytes()
 
 ### Type annotations
 
-|                                   |                                    |
-|-----------------------------------|------------------------------------|
-| `typing.AsyncIterable[int]`       | `typing.Iterable[int]`             |
-| `typing.AsyncIterator[int]`       | `typing.Iterator[int]`             |
-| `typing.AsyncGenerator[int, str]` | `typing.Generator[int, str, None]` |
-| `typing.Awaitable[str]`           | `str`                              |
+|                                            |                                             |
+|--------------------------------------------|---------------------------------------------|
+| `typing.AsyncIterable[int]`                | `typing.Iterable[int]`                      |
+| `collections.abc.AsyncIterable[int]`       | `collections.abc.Iterable[int]`             |
+| `typing.AsyncIterator[int]`                | `typing.Iterator[int]`                      |
+| `collections.abc.AsyncIterator[int]`       | `collections.abc.Iterator[int]`             |
+| `typing.AsyncGenerator[int, str]`          | `typing.Generator[int, str, None]`          |
+| `collections.abc.AsyncGenerator[int, str]` | `collections.abc.Generator[int, str, None]` |
+| `typing.Awaitable[str]`                    | `str`                                       |
+| `collections.abc.Awaitable[str]`           | `str`                                       |
 
 
 ### Docstrings

--- a/test/test_tree_transformer.py
+++ b/test/test_tree_transformer.py
@@ -291,6 +291,20 @@ def test_async_generator(transformer: TreeTransformer) -> None:
     assert transformer(dedent(source)) == dedent(expected)
 
 
+def test_async_generator_collections_abc(transformer: TreeTransformer) -> None:
+    source = """
+    from collections.abc import AsyncGenerator
+    x: AsyncGenerator
+    """
+
+    expected = """
+    from collections.abc import AsyncGenerator, Generator
+    x: Generator
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
 def test_async_generator_annotation(transformer: TreeTransformer) -> None:
     source = """
     from typing import AsyncGenerator
@@ -299,6 +313,22 @@ def test_async_generator_annotation(transformer: TreeTransformer) -> None:
 
     expected = """
     from typing import AsyncGenerator, Generator
+    x: Generator[str, int, None]
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_async_generator_annotation_collections_abc(
+    transformer: TreeTransformer,
+) -> None:
+    source = """
+    from collections.abc import AsyncGenerator
+    x: AsyncGenerator[str, int]
+    """
+
+    expected = """
+    from collections.abc import AsyncGenerator, Generator
     x: Generator[str, int, None]
     """
 
@@ -339,6 +369,24 @@ def test_async_generator_class(transformer: TreeTransformer) -> None:
     assert transformer(dedent(source)) == dedent(expected)
 
 
+def test_async_generator_class_collections_abc(transformer: TreeTransformer) -> None:
+    source = """
+    from collections.abc import AsyncGenerator
+
+    class Foo(AsyncGenerator[str, int]):
+        pass
+    """
+
+    expected = """
+    from collections.abc import AsyncGenerator, Generator
+
+    class Foo(Generator[str, int, None]):
+        pass
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
 def test_async_generator_class_typing_module_import(
     transformer: TreeTransformer,
 ) -> None:
@@ -359,6 +407,26 @@ def test_async_generator_class_typing_module_import(
     assert transformer(dedent(source)) == dedent(expected)
 
 
+def test_async_generator_class_collections_abc_module_import(
+    transformer: TreeTransformer,
+) -> None:
+    source = """
+    import collections.abc
+
+    class Foo(collections.abc.AsyncGenerator[str, int]):
+        pass
+    """
+
+    expected = """
+    import collections.abc
+
+    class Foo(collections.abc.Generator[str, int, None]):
+        pass
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
 def test_async_iterable_annotation(transformer: TreeTransformer) -> None:
     source = """
     from typing import AsyncIterable
@@ -367,6 +435,22 @@ def test_async_iterable_annotation(transformer: TreeTransformer) -> None:
 
     expected = """
     from typing import AsyncIterable, Iterable
+    x: Iterable[str, int]
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_async_iterable_annotation_collections_abc(
+    transformer: TreeTransformer,
+) -> None:
+    source = """
+    from collections.abc import AsyncIterable
+    x: AsyncIterable[str, int]
+    """
+
+    expected = """
+    from collections.abc import AsyncIterable, Iterable
     x: Iterable[str, int]
     """
 
@@ -389,6 +473,22 @@ def test_async_iterable_annotation_typing_module_import(
     assert transformer(dedent(source)) == dedent(expected)
 
 
+def test_async_iterable_annotation_collections_abc_module_import(
+    transformer: TreeTransformer,
+) -> None:
+    source = """
+    import collections.abc
+    x: collections.abc.AsyncIterable[str, int]
+    """
+
+    expected = """
+    import collections.abc
+    x: collections.abc.Iterable[str, int]
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
 def test_async_iterable_class(transformer: TreeTransformer) -> None:
     source = """
     from typing import AsyncIterable
@@ -399,6 +499,24 @@ def test_async_iterable_class(transformer: TreeTransformer) -> None:
 
     expected = """
     from typing import AsyncIterable, Iterable
+
+    class Foo(Iterable[str, int]):
+        pass
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_async_iterable_class_collections_abc(transformer: TreeTransformer) -> None:
+    source = """
+    from collections.abc import AsyncIterable
+
+    class Foo(AsyncIterable[str, int]):
+        pass
+    """
+
+    expected = """
+    from collections.abc import AsyncIterable, Iterable
 
     class Foo(Iterable[str, int]):
         pass
@@ -421,6 +539,26 @@ def test_async_iterable_class_typing_module_import(
     import typing
 
     class Foo(typing.Iterable[str, int]):
+        pass
+    """
+
+    assert transformer(dedent(source)) == dedent(expected)
+
+
+def test_async_iterable_class_collections_abc_module_import(
+    transformer: TreeTransformer,
+) -> None:
+    source = """
+    import collections.abc
+
+    class Foo(collections.abc.AsyncIterable[str, int]):
+        pass
+    """
+
+    expected = """
+    import collections.abc
+
+    class Foo(collections.abc.Iterable[str, int]):
         pass
     """
 
@@ -1075,6 +1213,8 @@ def test_unused_name_not_replaced() -> None:
 def test_unwrap_awaitable_annotation(transformer: TreeTransformer) -> None:
     source = """
     from typing import Awaitable, Callable
+    from collections import abc
+
 
     async def foo() -> Awaitable[None]:
         pass
@@ -1082,16 +1222,24 @@ def test_unwrap_awaitable_annotation(transformer: TreeTransformer) -> None:
     async def bar(fn: Callable[[], Awaitable[int]]) -> None:
         pass
 
+    async def baz() -> abc.Awaitable[None]:
+        pass
+
     aw: Awaitable[list[dict[str, int]]]
     """
 
     expected = """
     from typing import Awaitable, Callable
+    from collections import abc
+
 
     def foo() -> None:
         pass
 
     def bar(fn: Callable[[], int]) -> None:
+        pass
+
+    def baz() -> None:
         pass
 
     aw: list[dict[str, int]]

--- a/unasyncd/transformers.py
+++ b/unasyncd/transformers.py
@@ -34,8 +34,11 @@ NAME_REPLACEMENTS = {
     "StopAsyncIteration": "StopIteration",
     "contextlib.asynccontextmanager": "contextlib.contextmanager",
     "typing.AsyncIterable": "typing.Iterable",
+    "collections.abc.AsyncIterable": "collections.abc.Iterable",
     "typing.AsyncIterator": "typing.Iterator",
+    "collections.abc.AsyncIterator": "collections.abc.Iterator",
     "typing.AsyncGenerator": "typing.Generator",
+    "collections.abc.AsyncGenerator": "collections.abc.Generator",
     "asyncio.sleep": "time.sleep",
     "anyio.sleep": "time.sleep",
     "anyio.Path": "pathlib.Path",
@@ -804,10 +807,13 @@ class _AsyncTransformer(_ReplaceNamesMixin, cst.CSTTransformer):
         ``typing.Generator[None, None, None]``.
         """
         qualified_name = self.get_qualified_name(original_node)
-        if qualified_name == "typing.AsyncGenerator":
+        if qualified_name in (
+            "typing.AsyncGenerator",
+            "collections.abc.AsyncGenerator",
+        ):
             return self._fix_async_generator(updated_node)
 
-        if qualified_name == "typing.Awaitable":
+        if qualified_name in ("typing.Awaitable", "collections.abc.Awaitable"):
             return self._transform_awaitable(updated_node)
 
         return updated_node


### PR DESCRIPTION
Support `AsyncGenerator`, `AsyncIterable`, `AsyncIterator` and `Awaitable` when imported from `collections.abc`