### PR TITLE
fix: migrate from tool.uv.dev-dependencies to dependency-groups.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
 ruff = ["ruff"]
 
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest",
     "pre-commit~=3.3.2",
     "pytest-mock~=3.10.0",


### PR DESCRIPTION
Avoid the warning:
> The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead